### PR TITLE
test(contracts): quick-lane boundary tests for orders & payments

### DIFF
--- a/server/tests/bootstrap.ts
+++ b/server/tests/bootstrap.ts
@@ -6,8 +6,21 @@ import { beforeAll, afterAll, afterEach, vi } from 'vitest';
 // Configure test environment variables
 process.env.NODE_ENV = 'test';
 process.env.PORT = '0'; // Use random port for tests
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.SUPABASE_SERVICE_KEY = 'test-service-key';
 process.env.SUPABASE_JWT_SECRET = 'test-jwt-secret-for-testing-only';
+process.env.DEFAULT_RESTAURANT_ID = 'test-restaurant-123';
 process.env.KIOSK_JWT_SECRET = 'test-kiosk-jwt-secret';
+process.env.STATION_TOKEN_SECRET = 'test-station-secret';
+process.env.PIN_PEPPER = 'test-pepper';
+process.env.DEVICE_FINGERPRINT_SALT = 'test-salt';
+process.env.SQUARE_ACCESS_TOKEN = 'test-square-token';
+process.env.SQUARE_ENVIRONMENT = 'sandbox';
+process.env.SQUARE_LOCATION_ID = 'test-location';
+process.env.SQUARE_APP_ID = 'test-app';
+// AI config can be optional in tests
+process.env.AI_DEGRADED_MODE = 'true';
 
 // Clean up after each test
 afterEach(() => {

--- a/server/tests/contracts/order.contract.test.ts
+++ b/server/tests/contracts/order.contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { OrderPayload } from '../../../shared/contracts/order';
+
+describe('Order Contract Validation', () => {
+  describe('OrderPayload schema', () => {
+    it('should accept valid camelCase order payload', () => {
+      const validOrder = {
+        type: 'dine_in',
+        tableNumber: 5,
+        customerName: 'John Doe',
+        items: [
+          {
+            itemId: 'item-123',
+            quantity: 2,
+            notes: 'No onions'
+          }
+        ]
+      };
+
+      const result = OrderPayload.safeParse(validOrder);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('dine_in');
+      }
+    });
+
+    it('should reject snake_case order payload', () => {
+      const snakeCaseOrder = {
+        order_type: 'dine_in',                 // snake_case (should be 'type')
+        table_number: 5,                       // snake_case (correct field)
+        customer_name: 'John Doe',             // snake_case (correct field)
+        items: [
+          {
+            item_id: 'item-123',              // snake_case (should be 'itemId')
+            quantity: 2,
+            special_notes: 'No onions'        // snake_case (should be 'notes')
+          }
+        ]
+      };
+
+      const result = OrderPayload.safeParse(snakeCaseOrder);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject missing required fields', () => {
+      const invalidOrder = {
+        tableNumber: 5,
+        // Missing type and items
+      };
+
+      const result = OrderPayload.safeParse(invalidOrder);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues.map(i => i.path[0]);
+        expect(issues).toContain('type');
+        expect(issues).toContain('items');
+      }
+    });
+
+    it('should require at least one item', () => {
+      const orderNoItems = {
+        type: 'dine_in',
+        customerName: 'John Doe',
+        items: []  // Empty items array
+      };
+
+      const result = OrderPayload.safeParse(orderNoItems);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues;
+        expect(issues.some(i => i.message.includes('at least 1'))).toBe(true);
+      }
+    });
+
+    it('should accept optional fields', () => {
+      const orderWithOptionals = {
+        type: 'delivery',
+        customerName: 'John Doe',
+        tableNumber: 0,
+        items: [
+          {
+            itemId: 'item-123',
+            quantity: 1,
+            notes: 'Extra sauce'
+          }
+        ]
+      };
+
+      const result = OrderPayload.safeParse(orderWithOptionals);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.customerName).toBe('John Doe');
+        expect(result.data.tableNumber).toBe(0);
+      }
+    });
+  });
+});

--- a/server/tests/contracts/payment.contract.test.ts
+++ b/server/tests/contracts/payment.contract.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { PaymentPayload } from '../../../shared/contracts/payment';
+
+describe('Payment Contract Validation', () => {
+  describe('PaymentPayload schema', () => {
+    it('should validate required fields', () => {
+      const invalidPayload = {
+        // Missing orderId and token
+        amount: 100
+      };
+
+      const result = PaymentPayload.safeParse(invalidPayload);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues.map(i => i.path[0]);
+        expect(issues).toContain('orderId');
+        expect(issues).toContain('token');
+      }
+    });
+
+    it('should accept optional amount (server computes)', () => {
+      const paymentWithAmount = {
+        orderId: 'order-123',
+        token: 'tok_test_123',
+        amount: 1, // Client tries to pay $1 for a $100 order
+        idempotencyKey: 'client-key-123'
+      };
+
+      // Schema accepts it, but server will override
+      const result = PaymentPayload.safeParse(paymentWithAmount);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Amount is in the schema but optional
+        expect(result.data.amount).toBe(1);
+      }
+    });
+
+    it('should accept idempotency key', () => {
+      const paymentPayload = {
+        orderId: 'order-456',
+        token: 'tok_test_456',
+        idempotencyKey: 'idem-key-456'
+      };
+
+      const result = PaymentPayload.safeParse(paymentPayload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.idempotencyKey).toBe('idem-key-456');
+      }
+    });
+
+    it('should reject empty token', () => {
+      const invalidTokenPayload = {
+        orderId: 'order-789',
+        token: '', // Empty token
+        amount: 50
+      };
+
+      const result = PaymentPayload.safeParse(invalidTokenPayload);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const tokenIssue = result.error.issues.find(i => i.path[0] === 'token');
+        expect(tokenIssue).toBeDefined();
+        expect(tokenIssue?.message).toContain('at least 1');
+      }
+    });
+
+    it('should allow optional verification token for 3D Secure', () => {
+      const paymentWith3DS = {
+        orderId: 'order-3ds',
+        token: 'tok_test_3ds',
+        verificationToken: 'verf_token_123'
+      };
+
+      const result = PaymentPayload.safeParse(paymentWith3DS);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.verificationToken).toBe('verf_token_123');
+      }
+    });
+
+    it('should reject negative amounts', () => {
+      const negativeAmount = {
+        orderId: 'order-neg',
+        token: 'tok_test_neg',
+        amount: -50
+      };
+
+      const result = PaymentPayload.safeParse(negativeAmount);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const amountIssue = result.error.issues.find(i => i.path[0] === 'amount');
+        expect(amountIssue).toBeDefined();
+        expect(amountIssue?.message).toContain('greater than 0');
+      }
+    });
+
+    it('should reject short idempotency keys', () => {
+      const shortKey = {
+        orderId: 'order-short',
+        token: 'tok_test_short',
+        idempotencyKey: 'short' // Less than 10 chars
+      };
+
+      const result = PaymentPayload.safeParse(shortKey);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const keyIssue = result.error.issues.find(i => i.path[0] === 'idempotencyKey');
+        expect(keyIssue).toBeDefined();
+        expect(keyIssue?.message).toContain('at least 10');
+      }
+    });
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,14 +1,21 @@
 import { defineConfig } from 'vitest/config';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 const qFile = join(__dirname, 'tests', 'quarantine.list');
 const qList = existsSync(qFile) ? readFileSync(qFile, 'utf8').split('\n').map(s=>s.trim()).filter(Boolean) : [];
 export default defineConfig({
+  resolve: {
+    alias: {
+      'shared': resolve(__dirname, '../shared')
+    }
+  },
   test: {
     environment: 'node',
+    include: ['tests/**/*.test.ts'],           // allow our contract tests
     testTimeout: 15000,
     hookTimeout: 15000,
-    exclude: ['**/node_modules/**','**/dist/**','**/tests/quarantine/**','tests/**/*.{test,spec}.{ts,tsx}', ...qList],
+    exclude: ['**/node_modules/**','**/dist/**','**/tests/quarantine/**', ...qList],
     passWithNoTests: true,
+    setupFiles: ['./tests/bootstrap.ts'],
   },
 });


### PR DESCRIPTION
## PLAN
- Enable server quick-lane contract tests: orders accept camelCase & reject snake_case (400); payments validate required fields & enforce constraints.

## FILES CHANGED
- server/vitest.config.ts
- server/tests/bootstrap.ts  
- server/tests/contracts/order.contract.test.ts
- server/tests/contracts/payment.contract.test.ts

## DIFF SUMMARY
- Fixed Vitest config to include tests under tests/** with proper alias resolution
- Updated bootstrap with complete test environment setup
- Added 5 boundary tests for OrderPayload schema validation
- Added 7 boundary tests for PaymentPayload schema validation

## CHECKS (local tails)
server quick:
```
Test Files  2 passed (2)
Tests  12 passed (12)
Duration 145ms
```

workspaces quick:
```
client: 1 passed (1)
server: 12 passed (12)
shared: no quick tests
```

## RISK & ROLLBACK
- Test-only changes; rollback: `git revert $(git rev-parse HEAD)`

## NEXT STEP
- Add CI workflow for quick tests and enable branch protection to require it.